### PR TITLE
Authorization Fix: Restrict Comment Editing to Original Owner

### DIFF
--- a/src/controllers/comment.controller.js
+++ b/src/controllers/comment.controller.js
@@ -94,8 +94,12 @@ const updateComment = asyncHandler(async (req, res) => {
     throw new ApiError(400, "comment not found");
   }
 
-  if (comment._id != req.user._id) {
-    throw new ApiError(400, "Unauthorised request");
+  // if (comment._id != req.user._id) {
+  //   throw new ApiError(400, "Unauthorised request");
+  // }
+
+  if (comment.owner.toString() !== req.user._id.toString()) {
+    throw new ApiError(403, "Unauthorized request: You do not own this comment");
   }
 
   comment.content = content;


### PR DESCRIPTION
This pull request fixes an authorization issue in the comment update functionality. Previously, the check used **comment._id != req.user._id**, which incorrectly compared the comment’s ID with the user’s ID. This has been corrected to 
**comment.owner.toString() !== req.user._id.toString()** to ensure only the original commenter (i.e., the comment owner) can edit their comment.

- Updated authorization logic to compare **comment.owner with req.user._id**
- Prevents unauthorized users from modifying comments they do not own.

This update improves security by enforcing proper ownership checks on comment updates.